### PR TITLE
Slow scroll and portrait images

### DIFF
--- a/src/InfiniteGrid.jsx
+++ b/src/InfiniteGrid.jsx
@@ -6,7 +6,8 @@ import usePan from './usePan.jsx'
 
 const COLS = 5
 const ROWS = 10
-const SIZE = 1
+const CELL_HEIGHT = 1
+const CELL_WIDTH = (CELL_HEIGHT * 9) / 16
 const VIEW_WIDTH = 3.33
 const VIEW_HEIGHT = 3
 
@@ -17,12 +18,13 @@ function wrap(value, size) {
 function Grid() {
   const { offset, bind } = usePan()
   const images = useMemo(
-    () => Array.from({ length: COLS * ROWS }, (_, i) => `https://picsum.photos/seed/${i}/512/512`),
+    () =>
+      Array.from({ length: COLS * ROWS }, (_, i) => `https://picsum.photos/seed/${i}/900/1600`),
     [],
   )
   const textures = useLoader(TextureLoader, images)
-  const totalWidth = COLS * SIZE
-  const totalHeight = ROWS * SIZE
+  const totalWidth = COLS * CELL_WIDTH
+  const totalHeight = ROWS * CELL_HEIGHT
 
   useFrame(() => {})
 
@@ -30,13 +32,16 @@ function Grid() {
   for (let c = 0; c < COLS; c += 1) {
     const speed = c % 2 === 1 ? 2 : 1
     for (let r = 0; r < ROWS; r += 1) {
-      const x = wrap(c * SIZE - offset.x, totalWidth) - totalWidth / 2 + SIZE / 2
+      const x =
+        wrap(c * CELL_WIDTH - offset.x, totalWidth) - totalWidth / 2 + CELL_WIDTH / 2
       const y =
-        wrap(r * SIZE - offset.y * speed, totalHeight) - totalHeight / 2 + SIZE / 2
+        wrap(r * CELL_HEIGHT - offset.y * speed, totalHeight) -
+        totalHeight / 2 +
+        CELL_HEIGHT / 2
       const index = c * ROWS + r
       planes.push(
         <mesh key={`${c}-${r}`} position={[x, y, 0]}>
-          <planeGeometry args={[SIZE, SIZE]} />
+          <planeGeometry args={[CELL_WIDTH, CELL_HEIGHT]} />
           <meshBasicMaterial map={textures[index]} />
         </mesh>,
       )

--- a/src/usePan.jsx
+++ b/src/usePan.jsx
@@ -6,6 +6,7 @@ export default function usePan() {
   const [offset, setOffset] = useState({ x: 0, y: 0 })
   const velocity = useRef({ x: 0, y: 0 })
   const isDragging = useRef(false)
+  const SPEED = 0.1
 
   const bind = useGesture(
     {
@@ -15,17 +16,23 @@ export default function usePan() {
         velocity.current.y = 0
       },
       onDrag: ({ delta: [dx, dy] }) => {
-        setOffset((o) => ({ x: o.x - dx, y: o.y + dy }))
-        velocity.current.x = -dx
-        velocity.current.y = dy
+        setOffset((o) => ({
+          x: o.x - dx * SPEED,
+          y: o.y + dy * SPEED,
+        }))
+        velocity.current.x = -dx * SPEED
+        velocity.current.y = dy * SPEED
       },
       onDragEnd: () => {
         isDragging.current = false
       },
       onWheel: ({ delta: [dx, dy] }) => {
-        setOffset((o) => ({ x: o.x - dx, y: o.y - dy }))
-        velocity.current.x = -dx
-        velocity.current.y = -dy
+        setOffset((o) => ({
+          x: o.x - dx * SPEED,
+          y: o.y - dy * SPEED,
+        }))
+        velocity.current.x = -dx * SPEED
+        velocity.current.y = -dy * SPEED
       },
     },
     { drag: { from: () => [0, 0] } },


### PR DESCRIPTION
## Summary
- slow down pan movements 10x
- resize images to portrait 9:16 aspect ratio

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2f2c11988322930e0491fcfc1614