### PR TITLE
Implement responsive square grid

### DIFF
--- a/src/InfiniteGrid.jsx
+++ b/src/InfiniteGrid.jsx
@@ -4,10 +4,6 @@ import { OrthographicCamera } from '@react-three/drei'
 import { TextureLoader } from 'three'
 import usePan from './usePan.jsx'
 
-const ROWS = 10
-const CELL_HEIGHT = 1
-const CELL_WIDTH = (CELL_HEIGHT * 9) / 16
-const VIEW_WIDTH = 3.33
 const VIEW_HEIGHT = 3
 
 function wrap(value, size) {
@@ -16,8 +12,12 @@ function wrap(value, size) {
 
 function Grid() {
   const { offset, bind } = usePan()
-  const { viewport } = useThree()
-  const cols = Math.ceil(viewport.width / CELL_WIDTH) + 1
+  const { viewport, size } = useThree()
+  const isMobile = size.width <= 600
+  const desiredCols = isMobile ? 2 : 3.5
+  const CELL_SIZE = viewport.width / desiredCols
+  const cols = Math.ceil(desiredCols) + 1
+  const rows = Math.ceil(viewport.height / CELL_SIZE) + 1
   const imageFiles = useMemo(
     () => [
       'download.jpeg',
@@ -30,47 +30,37 @@ function Grid() {
       'download (7).jpeg',
       'download (8).jpeg',
       'download (9).jpeg',
-      'download (10).jpeg',
-      'download (11).jpeg',
-      'download (12).jpeg',
-      'download (13).jpeg',
-      'download (14).jpeg',
-      'download (15).jpeg',
-      'download (16).jpeg',
-      'download (17).jpeg',
-      'download (18).jpeg',
-      'download (19).jpeg',
     ],
     [],
   )
   const images = useMemo(
     () =>
       Array.from(
-        { length: cols * ROWS },
+        { length: cols * rows },
         (_, i) => `/${imageFiles[i % imageFiles.length]}`,
       ),
-    [cols, imageFiles],
+    [cols, rows, imageFiles],
   )
   const textures = useLoader(TextureLoader, images)
-  const totalWidth = cols * CELL_WIDTH
-  const totalHeight = ROWS * CELL_HEIGHT
+  const totalWidth = cols * CELL_SIZE
+  const totalHeight = rows * CELL_SIZE
 
   useFrame(() => {})
 
   const planes = []
   for (let c = 0; c < cols; c += 1) {
     const speed = c % 2 === 1 ? 2 : 1
-    for (let r = 0; r < ROWS; r += 1) {
+    for (let r = 0; r < rows; r += 1) {
       const x =
-        wrap(c * CELL_WIDTH - offset.x, totalWidth) - totalWidth / 2 + CELL_WIDTH / 2
+        wrap(c * CELL_SIZE - offset.x, totalWidth) - totalWidth / 2 + CELL_SIZE / 2
       const y =
-        wrap(r * CELL_HEIGHT - offset.y * speed, totalHeight) -
+        wrap(r * CELL_SIZE - offset.y * speed, totalHeight) -
         totalHeight / 2 +
-        CELL_HEIGHT / 2
-      const index = c * ROWS + r
+        CELL_SIZE / 2
+      const index = c * rows + r
       planes.push(
         <mesh key={`${c}-${r}`} position={[x, y, 0]}>
-          <planeGeometry args={[CELL_WIDTH, CELL_HEIGHT]} />
+          <planeGeometry args={[CELL_SIZE, CELL_SIZE]} />
           <meshBasicMaterial map={textures[index]} />
         </mesh>,
       )


### PR DESCRIPTION
## Summary
- ensure images are square
- dynamically size cells so that 3.5 columns appear on desktop and 2 on mobile
- limit the image set to 10

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c3b2e88f88322a4ab623bfe28e650