### PR TITLE
Adjust grid layout

### DIFF
--- a/src/InfiniteGrid.jsx
+++ b/src/InfiniteGrid.jsx
@@ -1,15 +1,15 @@
 import { useMemo } from 'react';
 import { Canvas, useFrame, useLoader, useThree } from '@react-three/fiber';
-import { OrthographicCamera } from '@react-three/drei';
+import { OrthographicCamera, RoundedBox } from '@react-three/drei';
 import { TextureLoader } from 'three';
 import usePan from './usePan.jsx';
 
-//testing
-const ROWS = 10;
-const CELL_HEIGHT = 1;
-const CELL_WIDTH = (CELL_HEIGHT * 9) / 16;
-const VIEW_WIDTH = 3.33;
+// configuration
 const VIEW_HEIGHT = 3;
+const VISIBLE_ROWS = 1.5;
+const VISIBLE_COLS = 3.5;
+const GAP_PX = 5;
+const RADIUS_PX = 5;
 
 function wrap(value, size) {
   return ((value % size) + size) % size;
@@ -17,8 +17,18 @@ function wrap(value, size) {
 
 function Grid() {
   const { offset, bind } = usePan();
-  const { viewport } = useThree();
-  const cols = Math.ceil(viewport.width / CELL_WIDTH) + 1;
+  const { viewport, size } = useThree();
+
+  const gapX = (GAP_PX / size.width) * viewport.width;
+  const gapY = (GAP_PX / size.height) * viewport.height;
+
+  const cellWidth =
+    (viewport.width - (VISIBLE_COLS + 1) * gapX) / VISIBLE_COLS;
+  const cellHeight =
+    (viewport.height - (VISIBLE_ROWS + 1) * gapY) / VISIBLE_ROWS;
+
+  const cols = Math.ceil(viewport.width / (cellWidth + gapX)) + 2;
+  const rows = Math.ceil(viewport.height / (cellHeight + gapY)) + 2;
   const imageFiles = useMemo(
     () => [
       'download.jpeg',
@@ -37,35 +47,46 @@ function Grid() {
   const images = useMemo(
     () =>
       Array.from(
-        { length: cols * ROWS },
+        { length: cols * rows },
         (_, i) => `/${imageFiles[i % imageFiles.length]}`
       ),
-    [cols, imageFiles]
+    [cols, rows, imageFiles]
   );
+
   const textures = useLoader(TextureLoader, images);
-  const totalWidth = cols * CELL_WIDTH;
-  const totalHeight = ROWS * CELL_HEIGHT;
+
+  const totalWidth = cols * (cellWidth + gapX);
+  const totalHeight = rows * (cellHeight + gapY);
 
   useFrame(() => {});
 
   const planes = [];
   for (let c = 0; c < cols; c += 1) {
     const speed = c % 2 === 1 ? 2 : 1;
-    for (let r = 0; r < ROWS; r += 1) {
+    for (let r = 0; r < rows; r += 1) {
       const x =
-        wrap(c * CELL_WIDTH - offset.x, totalWidth) -
+        wrap(c * (cellWidth + gapX) - offset.x, totalWidth) -
         totalWidth / 2 +
-        CELL_WIDTH / 2;
+        cellWidth / 2 +
+        gapX / 2;
       const y =
-        wrap(r * CELL_WIDTH - offset.y * speed, totalHeight) -
+        wrap(r * (cellHeight + gapY) - offset.y * speed, totalHeight) -
         totalHeight / 2 +
-        CELL_HEIGHT / 2;
-      const index = c * ROWS + r;
+        cellHeight / 2 +
+        gapY / 2;
+      const index = c * rows + r;
       planes.push(
-        <mesh key={`${c}-${r}`} position={[x, y, 0]}>
-          <planeGeometry args={[CELL_WIDTH, CELL_WIDTH]} />
+        <RoundedBox
+          key={`${c}-${r}`}
+          position={[x, y, 0]}
+          args={[cellWidth, cellHeight, 0.01]}
+          radius={Math.min(
+            (RADIUS_PX / size.width) * viewport.width,
+            (RADIUS_PX / size.height) * viewport.height
+          )}
+        >
           <meshBasicMaterial map={textures[index]} />
-        </mesh>
+        </RoundedBox>
       );
     }
   }


### PR DESCRIPTION
## Summary
- revert to mesh-based images to avoid blank render
- allow configuration of how many rows/columns are visible
- keep 5px gap and rounded borders with `RoundedBox`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ec2d6a5788322973667c68583e72f